### PR TITLE
Limited image preview size to 500px in kml.fmt

### DIFF
--- a/fmt_files/kml.fmt
+++ b/fmt_files/kml.fmt
@@ -11,7 +11,10 @@
 # Revisions:    2010/02/05 - P. Harvey created
 #               2013/02/05 - PH Fixed camera icon to work with new Google Earth
 #               2017/02/02 - PH Organize into folders based on file directory
-#               2018/01/04 - PH Added IF to be sure position exists
+#               2018/01/03 - PH Added IF to be sure position exists
+#               2020/01/11 - F. Kotov Limited image preview size to 500px. 
+#                            Changed xlmns to match KML written by Google Earth.
+#                            Removed unnecessary table from placemark description.
 #
 # Notes:     1) Input files must contain GPSLatitude and GPSLongitude.
 #            2) Add the -ee option to extract the full track from video files.
@@ -25,7 +28,7 @@
 #               generated placemarks when processing multiple files.
 #------------------------------------------------------------------------------
 #[HEAD]<?xml version="1.0" encoding="UTF-8"?>
-#[HEAD]<kml xmlns="http://earth.google.com/kml/2.0">
+#[HEAD]<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
 #[HEAD]  <Document>
 #[HEAD]    <name>My Photos</name>
 #[HEAD]    <open>1</open>
@@ -42,11 +45,9 @@
 #[SECT]      <open>0</open>
 #[IF]  $gpslatitude $gpslongitude
 #[BODY]      <Placemark>
-#[BODY]        <description><![CDATA[<br/><table><tr><td>
-#[BODY]        <img src='$main:directory/$main:filename'
-#[BODY]          width='$imagewidth' height='$imageheight'>
-#[BODY]        </td></tr></table>]]></description>
-#[BODY]        <Snippet/>
+#[BODY]        <description>
+#[BODY]         <![CDATA[<img src='$main:directory/$main:filename' style="max-width:500px;"> ]]>
+#[BODY]        </description>
 #[BODY]        <name>$filename</name>
 #[BODY]        <styleUrl>#Photo</styleUrl>
 #[BODY]        <Point>


### PR DESCRIPTION
Updated kml.fmt. 
- Limited image preview size to 500px. Resolution of images from modern cameras is often too large to fit on screen.
- Changed xlmns to match KML written by Google Earth.
- Removed unnecessary table from placemark description.